### PR TITLE
fix file serve

### DIFF
--- a/system/core/file/serve.js
+++ b/system/core/file/serve.js
@@ -144,11 +144,10 @@ var _getFileLocation = function f_file_serve_addFileData($fileObject) {
                 }
                 else {
 
-                    $fileObject.stats = $stats;
-
                     $res({
 
                         path: pathList[dex],
+                        stats: $stats,
                     });
                 }
             });
@@ -166,6 +165,7 @@ var _getFileLocation = function f_file_serve_addFileData($fileObject) {
             if (!$vals[i].failed) {
 
                 $fileObject.path = $vals[i].path;
+                $fileObject.stats = $vals[i].stats;
                 d.resolve($fileObject);
                 return;
             }


### PR DESCRIPTION
When multiple files with the same name are found, the file stats and the file path might get mixed up.
This patch bundles the stats with the path and then determines which stats/path pair will be used for serving the request.